### PR TITLE
feat: baseline profile

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -2,6 +2,8 @@ module github.com/pyroscope-io/otelpyroscope/example
 
 go 1.16
 
+replace github.com/pyroscope-io/otelpyroscope => ../
+
 require (
 	github.com/pyroscope-io/otelpyroscope v0.1.0
 	go.opentelemetry.io/otel v1.4.1

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,5 +1,6 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -10,7 +11,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pyroscope-io/otelpyroscope v0.1.0 h1:LDRYGrFhQUZT7rbJ1PCMOL0TGjNk/SNJbh3Ri7l8OFg=
 github.com/pyroscope-io/otelpyroscope v0.1.0/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opentelemetry.io/otel v1.4.1 h1:QbINgGDDcoQUoMJa2mMaWno49lja9sHwp6aoa2n3a4g=
@@ -21,6 +25,7 @@ go.opentelemetry.io/otel/sdk v1.4.1 h1:J7EaW71E0v87qflB4cDolaqq3AcujGrtyIPGQoZOB
 go.opentelemetry.io/otel/sdk v1.4.1/go.mod h1:NBwHDgDIBYjwK2WNu1OPgsIc2IJzmBXNnvIJxJc8BpE=
 go.opentelemetry.io/otel/trace v1.4.1 h1:O+16qcdTrT7zxv2J6GejTPFinSwA++cYerC5iSiF8EQ=
 go.opentelemetry.io/otel/trace v1.4.1/go.mod h1:iYEVbroFCNut9QkwEczV9vMRPHNKSSwYZjulEtsmhFc=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 h1:iGu644GcxtEcrInvDsQRCwJjtCIOlT2V7IRt6ah2Whw=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/example/main.go
+++ b/example/main.go
@@ -50,8 +50,12 @@ func initTracer() *trace.TracerProvider {
 		trace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp,
-		otelpyroscope.WithDefaultProfileURLBuilder("http://localhost:4040", "example-app"),
+		otelpyroscope.WithAppName("example-app"),
+		otelpyroscope.WithPyroscopeURL("http://localhost:4040"),
 		otelpyroscope.WithRootSpanOnly(true),
+		otelpyroscope.WithAddSpanName(true),
+		otelpyroscope.WithProfileURL(true),
+		otelpyroscope.WithProfileBaselineURL(true),
 	))
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},

--- a/otelpyroscope.go
+++ b/otelpyroscope.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	profileIDLabelName   = "profile_id"
-	profileNameLabelName = "profile_name"
+	profileIDLabelName = "profile_id"
+	spanNameLabelName  = "span_name"
 )
 
 var (
@@ -147,7 +147,7 @@ func NewTracerProvider(tp trace.TracerProvider, options ...Option) trace.TracerP
 func DefaultProfileURLBuilder(addr, app string) func(string) string {
 	return func(id string) string {
 		q := make(url.Values, 1)
-		q.Set("query", app+`.cpu{profile_id="`+id+`"}`)
+		q.Set("query", app+`.cpu{`+profileIDLabelName+`="`+id+`"}`)
 		return addr + "?" + q.Encode()
 	}
 }
@@ -176,7 +176,7 @@ func (w profileTracer) Start(ctx context.Context, spanName string, opts ...trace
 
 	labels := []string{profileIDLabelName, s.profileID}
 	if w.p.config.AddSpanName && spanName != "" {
-		labels = append(labels, profileNameLabelName, spanName)
+		labels = append(labels, spanNameLabelName, spanName)
 	}
 
 	ctx = pprof.WithLabels(ctx, pprof.Labels(labels...))


### PR DESCRIPTION
The PR extends tracer provider API:
 - `WithAddSpanName` - if enabled, the root span name will be added to profile labels automatically.
 - `WithProfileBaselineURL` - if enabled, the root span will be annotated with `pyroscope.profile.baseline.url` attribute containing URL to the baseline profile. See https://github.com/pyroscope-io/pyroscope/issues/964 for details. 
 - Slightly refactored existing configuration options.

There is a flaw that we can't eliminate easily: users have to pass static labels (pyroscope profiler tags) to the tracer constructor explicitly so that we could include them to the baseline profile query. 

Every profile may have two types of labels:
 1. *Static* labels are specified in the pyroscope profiler config and never change. In runtime, we can't access them outside the profiler.
 2. *Dynamic* labels can be changed by user (e.g via `pprof.Do`) at any time, they are part of the pprof data.

Ideally, we should build and store the query (or just labels and time range) on the server side on receiving when we have both static and dynamic labels.